### PR TITLE
Add target for automated testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,19 @@ install(TARGETS libfort
 
 # Tests
 macro(add_libfort_test name)
+  # Generate CTest tests
+  enable_testing()
+  # Current test set up
   add_executable( ${name} ${ARGN} )
   target_link_libraries( ${name} libfort )
+  # Add to CTest
+  add_test (NAME ${name} COMMAND ${name} ${ARGN})
+  # Create target `check` and make sure it depends on all test executables
+  if (NOT TARGET check)
+    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS ${name})
+  else()
+    add_dependencies(check ${name})
+  endif()
 endmacro(add_libfort_test)
 
 add_subdirectory(test)

--- a/README.txt
+++ b/README.txt
@@ -17,10 +17,6 @@ Building Libfortrt
 > mkdir build
 > cd build & cmake ../ -DCMAKE_INSTALL_PREFIX=/usr
 > cd build & make
+> cd build & make check
 > cd build & make install
 
-
-TODO
-================================
-- IO, Formatted IO.
-- Fortran 90/95 support.


### PR DESCRIPTION
`check` target runs all the tests and makes sure they are (re)built before
execution.

README: Remove TODO list, as IO and Fortran 90 are partially implemented.